### PR TITLE
refractor help content and structure

### DIFF
--- a/src/components/sidebar/Help.js
+++ b/src/components/sidebar/Help.js
@@ -93,7 +93,7 @@ const Help = ({ isActive }) => {
       example: ['start\n#Console with some fun style!\nimport(IO)\nstyle{\nunderline(true)\nitalic(true)\ntext_align(center)\npaint(blue)\n}\nconsoleWrite("Hello!")\nend'],
       argument: [{
         name: 'style',
-        desc: 'Style the console window.\nunderline - Make the text underlined in console window.\nitalic - Make the text italisized in console window.\bold - Make the text bold in console window.\ntext_align : left, center, or right - Set the alignment of the text in console window.\ntext_size : xx-large, x-large, larger, large, medium, small, smaller, x-small or xx-small - Set the size of the text in console window.\ntext_color : black, white, blue, brown, gray, grey, green, orange, pink, purple, red, yellow - Set the color of the text in console window.\npaint : black, white, blue, brown, gray, grey, green, orange, pink, purple, red, yellow - Paint the background color of the console window.',
+        desc: 'Style the console window.\nunderline - Make the text underlined in console window.\nitalic - Make the text italisized in console window.\nbold - Make the text bold in console window.\ntext_align : left, center, or right - Set the alignment of the text in console window.\ntext_size : xx-large, x-large, larger, large, medium, small, smaller, x-small or xx-small - Set the size of the text in console window.\ntext_color : black, white, blue, brown, gray, grey, green, orange, pink, purple, red, yellow - Set the color of the text in console window.\npaint : black, white, blue, brown, gray, grey, green, orange, pink, purple, red, yellow - Paint the background color of the console window.',
       }],
     },
   ];


### PR DESCRIPTION
Fixed:

- 'end' command examples added
- initially selected help tab is the one first displayed
- arguments for all functions in the example should be on the same line